### PR TITLE
Default value is value for a TextArea

### DIFF
--- a/src/EditableTextArea.js
+++ b/src/EditableTextArea.js
@@ -50,7 +50,7 @@ export default class EditableTextArea extends React.Component {
       let content = <pre>{this.state.value}</pre>;
       if (!this.state.value) {
         aClassName += ' editable-empty';
-        content = this.state.defaultText;
+        content = this.state.value || this.state.defaultText;
       }
       return <a href='javascript:;' className={aClassName} style={this.state.textStyle} onClick={this.handleLinkClick}>
         {content}


### PR DESCRIPTION
In TextField, the displayed text is `value` if defined. If not, `defaultText`, and if not `Empty` is displayed. In TextArea, if `defaultValue` isn't defined, you had `Empty` anyway. With this small change, if works like `TextField`.