### PR TITLE
Update d.ts for ignore allowSyntheticDefaultImports option in tsconfig

### DIFF
--- a/d.ts/EditableSelect.d.ts
+++ b/d.ts/EditableSelect.d.ts
@@ -1,5 +1,5 @@
 // Import React
-import React from 'react';
+import * as React from 'react';
 
 // <EditableSelect />
 // ----------------------------------------

--- a/d.ts/EditableTextArea.d.ts
+++ b/d.ts/EditableTextArea.d.ts
@@ -1,5 +1,5 @@
 // Import React
-import React from 'react';
+import * as React from 'react';
 
 // <EditableTextArea />
 // ----------------------------------------

--- a/d.ts/EditableTextField.d.ts
+++ b/d.ts/EditableTextField.d.ts
@@ -1,5 +1,5 @@
 // Import React
-import React from 'react';
+import * as React from 'react';
 
 // <EditableTextField />
 // ----------------------------------------


### PR DESCRIPTION
Typescript use `import * as Module from 'module'` syntax to import,
but the old written caused to need define allowSyntheticDefaultImports
in tsconfig.json to make sure compile pass.

Please see https://www.typescriptlang.org/docs/handbook/modules.html#import
